### PR TITLE
DEVELOP-503: Update title

### DIFF
--- a/config/multiqc_flowcell_config.yaml
+++ b/config/multiqc_flowcell_config.yaml
@@ -1,6 +1,6 @@
 # Config for flowcell Reports
 
-subtitle: "SNP&SEQ Technology Platform"
+subtitle: "NGI Uppsala - SNP&SEQ Technology Platform"
 intro_text: |
   This is a report containing quality control information about your project run at the SNP&SEQ Technology
   Platform. If you have any questions, please do not hesitate to contact us at

--- a/config/multiqc_project_config.yaml
+++ b/config/multiqc_project_config.yaml
@@ -1,6 +1,6 @@
 # Config for project reports
 
-subtitle: "SNP&SEQ Technology Platform"
+subtitle: "NGI Uppsala - SNP&SEQ Technology Platform"
 intro_text: |
   This is a report containing quality control information about your project run at the SNP&SEQ Technology
   Platform. If you have any questions, please do not hesitate to contact us at

--- a/images/Singularity.checkqc
+++ b/images/Singularity.checkqc
@@ -2,5 +2,4 @@ Bootstrap: docker
 From: python:3.6-stretch
 
 %post
-  pip install checkqc
-  git clone https://github.com/Molmed/summary-report-development.git
+  pip install checkqc==3.3.1

--- a/main.nf
+++ b/main.nf
@@ -138,7 +138,7 @@ process MultiQCPerFlowcell {
 
     """
     multiqc \
-        --title "Flowcell Report for ${runfolder.getFileName()}" \
+        --title "Flowcell report for ${runfolder.getFileName()}" \
         -m fastqc -m fastq_screen -m bcl2fastq -m interop -c $config \
         --disable_clarity -c $qc_thresholds \
         .
@@ -173,7 +173,7 @@ process MultiQCPerProject {
 
     """
     multiqc \
-        --title "Report for Project $project on Runfolder ${runfolder.getFileName()}" \
+        --title "Report for project $project on runfolder ${runfolder.getFileName()}" \
         -m fastqc -m fastq_screen \
         --clarity_project $project \
         -o $project \

--- a/main.nf
+++ b/main.nf
@@ -45,8 +45,12 @@ multiqc_project_config = file(params.multiqc_project_config)
 
 fastq_screen_db = file(params.fastq_screen_db)
 
+params.checkqc_config = ""
+
 params.assets = "assets/"
 assets = file(params.assets)
+
+get_qc_config_script = file("bin/get_qc_config.py")
 
 // ---------------------------------------------------
 // Create directories where results should be written.
@@ -102,18 +106,24 @@ process FastqScreen {
 
 fastq_screen_results.into{ fastq_screen_results_for_flowcell;  fastq_screen_results_for_project_ungrouped }
 
-checkqc_config = file(params.checkqc_config)
-
 process GetQCThresholds {
   input:
   file runfolder
-  file checkqc_config
+  file get_qc_config_script
 
   output:
   file("qc_thresholds.yaml") into qc_thresholds_result
 
+  script:
+  if (params.checkqc_config.length() > 0){
+      checkqc_config_section = "--config ${params.checkqc_config}"
+  }
+  else{
+      checkqc_config_section = ""
+  }
+
   """
-  /summary-report-development/bin/get_qc_config.py --runfolder $runfolder --config $checkqc_config
+  python $get_qc_config_script --runfolder $runfolder $checkqc_config_section
 
   """
 


### PR DESCRIPTION
This PR includes the following changes: 
- Updated titles and subtitles
- The checkqc_config parameter is now optional. The default checkqc config will be used if not specified.
- `get_qc_config.py` will now be linked to the work area rather than installed in the image. This is not the way other nf-core pipelines does it, so we might want to change it later. For now I think it's more convenient to do it this way. 