### PR TITLE
DEVELOP-500: Metadata table

### DIFF
--- a/bin/get_metadata.py
+++ b/bin/get_metadata.py
@@ -1,0 +1,107 @@
+#!/usr/bin/env python
+from __future__ import print_function
+import xmltodict
+from collections import OrderedDict
+import re
+import argparse
+import os
+import json
+
+class RunfolderInfo():
+
+    def __init__(self, runfolder):
+        self.runfolder = runfolder
+        self.run_parameters = self.read_run_parameters()
+        self.stats_json = self.read_stats_json()
+        self.description_and_identifier = OrderedDict()
+        self.run_parameters_tags = \
+            {'RunId': 'Run ID', 'RunID': 'Run ID',
+             'ApplicationName': 'Control software', 'Application': 'Control software',
+             'ApplicationVersion': 'Control software version',
+             'Flowcell': 'Flowcell type', 'FlowCellMode': 'Flowcell type',
+             'ReagentKitVersion': 'Reagent kit version',
+             'RTAVersion': 'RTA Version', 'RtaVersion': 'RTA Version',
+            }
+
+    def find(self, d, tag):
+        if tag in d:
+            yield d[tag]
+        for k, v in d.items():
+            if isinstance(v, dict):
+                for i in self.find(v, tag):
+                    yield i
+
+    def read_run_parameters(self):
+        alt_1 = os.path.join(self.runfolder, "runParameters.xml")
+        alt_2 = os.path.join(self.runfolder, "RunParameters.xml")
+        if os.path.exists(alt_1):
+            with open(alt_1) as f:
+                return xmltodict.parse(f.read())
+        elif os.path.exists(alt_2):
+            with open(alt_2) as f:
+                return xmltodict.parse(f.read())
+        else:
+            return None
+
+    def read_stats_json(self):
+        stats_json_path = os.path.join(self.runfolder, "Unaligned/Stats/Stats.json")
+        if os.path.exists(stats_json_path):
+            with open(stats_json_path) as f:
+                return json.load(f)
+        else:
+            return None
+
+    def get_bcl2fastq_version(self, runfolder):
+        with open(os.path.join(runfolder, "bcl2fastq_version")) as f:
+            bcl2fastq_str = f.read()
+        return bcl2fastq_str.split("v")[1].strip()
+
+    def get_run_parameters(self):
+        results = OrderedDict()
+        for key, value in self.run_parameters_tags.items():
+            info = list(self.find(self.run_parameters, key))
+            if info:
+                results[value] = info[0]
+        return results
+
+    def get_read_cycles(self):
+        read_and_cycles = OrderedDict()
+        read_counter = 1
+        index_counter = 1
+        for read_info in self.stats_json["ReadInfosForLanes"][0]["ReadInfos"]:
+            if read_info["IsIndexedRead"]:
+                read_and_cycles[f"Index {index_counter} (bp)"] = read_info["NumCycles"]
+                index_counter += 1
+            else:
+                read_and_cycles[f"Read {read_counter} (bp)"] = read_info["NumCycles"]
+                read_counter += 1
+        return read_and_cycles
+
+    def get_info(self):
+        results = self.get_read_cycles()
+        results.update(self.get_run_parameters())
+        if os.path.exists(os.path.join(self.runfolder, "bcl2fastq_version")):
+            results['bcl2fastq version'] = self.get_bcl2fastq_version(self.runfolder)
+        return results
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description='Dumps a metadata yaml for MultiQC')
+    parser.add_argument('--runfolder', type=str, required=True, help='Path to runfolder')
+
+    args = parser.parse_args()
+    runfolder = args.runfolder
+
+    runfolder_info = RunfolderInfo(runfolder)
+    results = runfolder_info.get_info()
+
+    print ('''
+id: 'sequencing_metadata'
+section_name: 'Sequencing Metadata'
+plot_type: 'html'
+description: 'regarding the sequencing run'
+data: |
+    <dl class="dl-horizontal">
+''')
+    for k,v in results.items():
+        print("        <dt>{}</dt><dd><samp>{}</samp></dd>".format(k,v))
+    print ("    </dl>")

--- a/bin/get_metadata.py
+++ b/bin/get_metadata.py
@@ -29,8 +29,7 @@ class RunfolderInfo():
             yield d[tag]
         for k, v in d.items():
             if isinstance(v, dict):
-                for i in self.find(v, tag):
-                    yield i
+                yield from self.find(v, tag)
 
     def read_run_parameters(self):
         alt_1 = os.path.join(self.runfolder, "runParameters.xml")

--- a/bin/get_metadata.py
+++ b/bin/get_metadata.py
@@ -10,10 +10,10 @@ import json
 
 class RunfolderInfo():
 
-    def __init__(self, runfolder):
+    def __init__(self, runfolder, bcl2fastq_outdir):
         self.runfolder = runfolder
         self.run_parameters = self.read_run_parameters()
-        self.stats_json = self.read_stats_json()
+        self.stats_json = self.read_stats_json(bcl2fastq_outdir)
         self.description_and_identifier = OrderedDict()
         self.run_parameters_tags = \
             {'RunId': 'Run ID', 'RunID': 'Run ID',
@@ -43,9 +43,9 @@ class RunfolderInfo():
         else:
             return None
 
-    def read_stats_json(self):
+    def read_stats_json(self, bcl2fastq_outdir):
         stats_json_path = os.path.join(
-            self.runfolder, "Unaligned/Stats/Stats.json")
+            self.runfolder, bcl2fastq_outdir, "Stats/Stats.json")
         if os.path.exists(stats_json_path):
             with open(stats_json_path) as f:
                 return json.load(f)
@@ -95,11 +95,15 @@ if __name__ == "__main__":
         description='Dumps a metadata yaml for MultiQC')
     parser.add_argument('--runfolder', type=str,
                         required=True, help='Path to runfolder')
+    parser.add_argument('--bcl2fastq-outdir', type=str,
+                        default='Data/Intensities/BaseCalls',
+                        help='Path to bcl2fastq output folder relative to the runfolder')
 
     args = parser.parse_args()
     runfolder = args.runfolder
+    bcl2fastq_outdir = args.bcl2fastq_outdir
 
-    runfolder_info = RunfolderInfo(runfolder)
+    runfolder_info = RunfolderInfo(runfolder, bcl2fastq_outdir)
     results = runfolder_info.get_info()
 
     print ('''

--- a/bin/get_metadata.py
+++ b/bin/get_metadata.py
@@ -69,14 +69,17 @@ class RunfolderInfo():
         read_and_cycles = OrderedDict()
         read_counter = 1
         index_counter = 1
-        for read_info in self.stats_json["ReadInfosForLanes"][0]["ReadInfos"]:
-            if read_info["IsIndexedRead"]:
-                read_and_cycles[f"Index {index_counter} (bp)"] = read_info["NumCycles"]
-                index_counter += 1
-            else:
-                read_and_cycles[f"Read {read_counter} (bp)"] = read_info["NumCycles"]
-                read_counter += 1
-        return read_and_cycles
+        try:
+            for read_info in self.stats_json["ReadInfosForLanes"][0]["ReadInfos"]:
+                if read_info["IsIndexedRead"]:
+                    read_and_cycles[f"Index {index_counter} (bp)"] = read_info["NumCycles"]
+                    index_counter += 1
+                else:
+                    read_and_cycles[f"Read {read_counter} (bp)"] = read_info["NumCycles"]
+                    read_counter += 1
+            return read_and_cycles
+        except TypeError:
+            return read_and_cycles
 
     def get_info(self):
         results = self.get_read_cycles()

--- a/bin/get_metadata.py
+++ b/bin/get_metadata.py
@@ -7,6 +7,7 @@ import argparse
 import os
 import json
 
+
 class RunfolderInfo():
 
     def __init__(self, runfolder):
@@ -21,7 +22,7 @@ class RunfolderInfo():
              'Flowcell': 'Flowcell type', 'FlowCellMode': 'Flowcell type',
              'ReagentKitVersion': 'Reagent kit version',
              'RTAVersion': 'RTA Version', 'RtaVersion': 'RTA Version',
-            }
+             }
 
     def find(self, d, tag):
         if tag in d:
@@ -44,7 +45,8 @@ class RunfolderInfo():
             return None
 
     def read_stats_json(self):
-        stats_json_path = os.path.join(self.runfolder, "Unaligned/Stats/Stats.json")
+        stats_json_path = os.path.join(
+            self.runfolder, "Unaligned/Stats/Stats.json")
         if os.path.exists(stats_json_path):
             with open(stats_json_path) as f:
                 return json.load(f)
@@ -81,12 +83,16 @@ class RunfolderInfo():
         results = self.get_read_cycles()
         results.update(self.get_run_parameters())
         if os.path.exists(os.path.join(self.runfolder, "bcl2fastq_version")):
-            results['bcl2fastq version'] = self.get_bcl2fastq_version(self.runfolder)
+            results['bcl2fastq version'] = self.get_bcl2fastq_version(
+                self.runfolder)
         return results
 
+
 if __name__ == "__main__":
-    parser = argparse.ArgumentParser(description='Dumps a metadata yaml for MultiQC')
-    parser.add_argument('--runfolder', type=str, required=True, help='Path to runfolder')
+    parser = argparse.ArgumentParser(
+        description='Dumps a metadata yaml for MultiQC')
+    parser.add_argument('--runfolder', type=str,
+                        required=True, help='Path to runfolder')
 
     args = parser.parse_args()
     runfolder = args.runfolder
@@ -102,6 +108,6 @@ description: 'regarding the sequencing run'
 data: |
     <dl class="dl-horizontal">
 ''')
-    for k,v in results.items():
-        print("        <dt>{}</dt><dd><samp>{}</samp></dd>".format(k,v))
+    for k, v in results.items():
+        print("        <dt>{}</dt><dd><samp>{}</samp></dd>".format(k, v))
     print ("    </dl>")

--- a/config/multiqc_flowcell_config.yaml
+++ b/config/multiqc_flowcell_config.yaml
@@ -17,6 +17,7 @@ table_columns_visible:
         total_sequences: False
 
 top_modules:
+    - 'custom_content'
     - 'bcl2fastq'
     - 'interop'
 

--- a/config/multiqc_project_config.yaml
+++ b/config/multiqc_project_config.yaml
@@ -45,5 +45,8 @@ table_columns_visible:
     FastQC:
         percent_duplicates: False
 
+top_modules:
+    - 'custom_content'
+
 remove_sections:
     - 'fastqc_sequence_counts'

--- a/config/nextflow.config
+++ b/config/nextflow.config
@@ -35,6 +35,11 @@ process {
         container = "shub://Molmed/summary-report-development:checkqc"
         }
 }
+process {
+    withName:GetMetadata {
+        container = "shub://Molmed/summary-report-development:checkqc"
+        }
+}
 
 singularity {
     enabled = true

--- a/main.nf
+++ b/main.nf
@@ -6,6 +6,7 @@
 //          --runfolder ~/large_disk/180126_HSX122_0568_BHLFWLBBXX_small/ \
 //          --fastq_screen_db ~/large_disk/FastQ_Screen_Genomes/
 //          --checkqc_config /home/monika/git_workspace/summary-report-development/checkqc_config_monika.yaml
+//          --bcl2fastq_outdir Unaligned
 
 
 // ----------------
@@ -44,6 +45,8 @@ params.multiqc_project_config = "config/multiqc_project_config.yaml"
 multiqc_project_config = file(params.multiqc_project_config)
 
 fastq_screen_db = file(params.fastq_screen_db)
+
+params.bcl2fastq_outdir = ""
 
 params.checkqc_config = ""
 
@@ -141,8 +144,15 @@ process GetMetadata {
     file 'sequencing_metadata_mqc.yaml' into sequencing_metadata_yaml
 
     script:
+    if (params.bcl2fastq_outdir.length() > 0){
+        bcl2fastq_outdir_section = "--bcl2fastq-outdir ${params.bcl2fastq_outdir}"
+    }
+    else{
+        bcl2fastq_outdir_section = ""
+    }
+
     """
-    python $get_metadata_script --runfolder $runfolder &> sequencing_metadata_mqc.yaml
+    python $get_metadata_script --runfolder $runfolder $bcl2fastq_outdir_section &> sequencing_metadata_mqc.yaml
     """
 }
 


### PR DESCRIPTION
This PR adds a new section to the reports that contain metadata of the sequencing run (corresponds to the Run Parameters table in the sisyphus reports). The script that collects the data is designed to be as forgiving as possible: if a value can not be found, it is simply not added to the report. This approach makes it easier to handle the different data formats used by Illumina. 