### PR TITLE
Update clarity project info section

### DIFF
--- a/config/multiqc_project_config.yaml
+++ b/config/multiqc_project_config.yaml
@@ -15,12 +15,8 @@ clarity:
 
     report_header_info:
         Project:
-            'Application':
             'Kit for library preparation':
-            'DNA library insert size':
-            'Sequencing instrument':
-            'Read length bp':
-            'Project decription':
+            'Project name (from NGI-portal)':
 
     # TODO The sample level stats is something that we will need tp specify later.
     general_stats:


### PR DESCRIPTION
Removing application/sequencing info from the clarity project section, since it might be inaccurate on a project level according to project coordinators. Also use, project name instead of description. 