### PR TITLE
Add slurm profile to config

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,12 +29,12 @@ nextflow -c config/nextflow.config run main.nf \
 There are three different config profiles:
 - `standard`: For running locally
 - `dev`: Like standard but with less memory
-- `slurm`: For running on a server with the job scheduler slurm
+- `uppmax`: For running on an uppmax cluster with slurm
 
 Usage:
 ```
 nextflow run main.nf -profile dev <rest of the options>
 ```
 
-### slurm profile
-When using slurm, use the `--project` parameter to specify which project should be accounted for the running time
+### uppmax profile
+When using uppmax, use the `--project` parameter to specify which project should be accounted for the running time

--- a/README.md
+++ b/README.md
@@ -1,7 +1,5 @@
 # summary-report-development
-In this repository we will gather useful scripts that can be used in the process of developing new sequencing report at the SNP&amp;Seq Technology platform.
-
-This repository is not a repository for the final product and the final code. This is just a place to share scripts and ideas during the development process.
+This is a nextflow pipeline for generating sequencing reports for the SNP&amp;Seq Technology platform, NGI Uppsala, SciLifelab Genomics.
 
 # Pre-requisites
 You need to:
@@ -26,3 +24,17 @@ nextflow -c config/nextflow.config run main.nf \
           --runfolder ~/large_disk/180126_HSX122_0568_BHLFWLBBXX_small/ \
           --fastq_screen_db ~/large_disk/FastQ_Screen_Genomes/
 ```
+
+## Profiles
+There are three different config profiles:
+- `standard`: For running locally
+- `dev`: Like standard but with less memory
+- `slurm`: For running on a server with the job scheduler slurm
+
+Usage:
+```
+nextflow run main.nf -profile dev <rest of the options>
+```
+
+### slurm profile
+When using slurm, use the `--project` parameter to specify which project should be accounted for the running time

--- a/README.md
+++ b/README.md
@@ -29,12 +29,12 @@ nextflow -c config/nextflow.config run main.nf \
 There are three different config profiles:
 - `standard`: For running locally
 - `dev`: Like standard but with less memory
-- `uppmax`: For running on an uppmax cluster with slurm
+- `irma`: For running on uppmax cluster irma with slurm
 
 Usage:
 ```
 nextflow run main.nf -profile dev <rest of the options>
 ```
 
-### uppmax profile
-When using uppmax, use the `--project` parameter to specify which project should be accounted for the running time
+### irma profile
+When using the irma profile, use the `--project` parameter to specify which project should be accounted for the running time

--- a/config/nextflow.config
+++ b/config/nextflow.config
@@ -64,4 +64,13 @@ profiles {
         executor.cpus = '8'
         executor.memory = '32 G'
     }
+
+    slurm {
+        executor.name = 'slurm'
+        process.clusterOptions = { "-A $params.project" }
+        process.cpus = 4
+        process.memory = 16.GB
+        process.time = 5.h
+    }
+
 }

--- a/config/nextflow.config
+++ b/config/nextflow.config
@@ -65,12 +65,11 @@ profiles {
         executor.memory = '32 G'
     }
 
-    slurm {
+    uppmax {
         executor.name = 'slurm'
         process.clusterOptions = { "-A $params.project" }
-        process.cpus = 4
-        process.memory = 16.GB
-        process.time = 5.h
+        process.cpus = '1'
+        process.time = '5.h'
     }
 
 }

--- a/config/nextflow.config
+++ b/config/nextflow.config
@@ -65,11 +65,12 @@ profiles {
         executor.memory = '32 G'
     }
 
-    uppmax {
+    irma {
         executor.name = 'slurm'
         process.clusterOptions = { "-A $params.project" }
         process.cpus = '1'
         process.time = '5.h'
+        process.memory = '8 G'
     }
 
 }


### PR DESCRIPTION
This should make it possible to run the pipeline using slurm. 

I'm planning to follow this PR up with another one that removes the Clarity integration. We barely make use of it and it causes troubles when you can't connect to a Clarity LIMS (like the situation is for us on Uppmax cluster Irma).