### PR TITLE
Adjust report file names to arteria-delivery 

### DIFF
--- a/main.nf
+++ b/main.nf
@@ -229,7 +229,7 @@ process MultiQCPerProject {
     multiqc \
         --title "Report for project $project on runfolder $runfolder_name" \
         --ignore '*/Data/Intensities/BaseCalls/L00*' \
-        --filename $project"_"$runfolder_name"_multiqc_report" -z \
+        --filename $runfolder_name"_"$project"_multiqc_report" -z \
         -m fastqc -m fastq_screen -m custom_content \
         -o $project \
         -c $config_dir/multiqc_project_config.yaml \


### PR DESCRIPTION
I discovered that that I by mistake have mixed up the order of runfolder and project when adding support for the projects reports in arteria-delivery. 

This change makes the file correspond to the format expected by the delivery service. 

