### PR TITLE
Ignore if get qc thresholds fail

### DIFF
--- a/config/nextflow.config
+++ b/config/nextflow.config
@@ -32,6 +32,7 @@ process {
 
 process {
     withName:GetQCThresholds {
+        errorStrategy = 'ignore'
         container = "shub://Molmed/summary-report-development:checkqc"
         }
 }


### PR DESCRIPTION
This fixes the problem where the pipeline fails if a read length isn't defined in the CheckQC config.

It would be preferable to use the closest read length in the config (using the new feature of CheckQC), but I think we should migrate to DSL2 as soon as possible (WIP here: https://github.com/Molmed/summary-report-development/tree/dsl2_conversion), so let's implement new features in that version instead. 

Hopefully this is the last PR to the old code base.  