### PR TITLE
Take keyword

### DIFF
--- a/main.nf
+++ b/main.nf
@@ -116,7 +116,7 @@ workflow check_run_quality {
                                        -> FastqScreen   -> MultiQCPerFlowcell + MultiQCPerProject
     */
 
-    get:
+    take:
         run_folder
 
     main:

--- a/nextflow.config
+++ b/nextflow.config
@@ -4,7 +4,7 @@ manifest {
     homePage = ''
     description = 'A Nextflow run folder QC pipeline for SciLifeLab SNP&SEQ platform'
     mainScript = 'main.nf'
-    nextflowVersion = '>=19.10.0'
+    nextflowVersion = '!>=20.01.0'
     version = '1.0'
 }
 


### PR DESCRIPTION
In Nextflow version 20.01.0 the keyword `get` is deprecated and replaced with `take`. The `take` keyword does not work with Nextflow versions lower than 20.01.0. 