### PR TITLE
Fix executor configuration for snpseq profile

### DIFF
--- a/nextflow.config
+++ b/nextflow.config
@@ -14,7 +14,7 @@ profiles {
 
     dev {
         executor.name = 'local'
-        executor.memory = '12 G'
+        executor.memory = '12G'
         includeConfig "$baseDir/config/compute_resources.config"
     }
 
@@ -33,14 +33,16 @@ profiles {
     }
 
     snpseq {
+        executor {
+            name = 'local'
+            cpus = 8
+            memory = '32G'
+        }
         process {
             shell = ['/bin/bash', '-euo', 'pipefail']
             errorStrategy = { task.exitStatus in [255] ? 'retry' : 'terminate' }
             maxRetries = 2
-            scratch = true
-            executor = 'local'
             cpus = 1
-            memory = '32G'
         }
         includeConfig "$baseDir/config/compute_resources.config"
     }


### PR DESCRIPTION
Updated the executor configuration for the snpseq profile. The previous configuration incorrectly specified that each process should have 32 GB of memory, specifying it this way will instead set 32 GB of memory and 8 cpus as a global limit.  Also removed the scratch entry since we don't use it in the snpseq setting.  