### PR TITLE
Force interactive plots

### DIFF
--- a/config/multiqc_flowcell_config.yaml
+++ b/config/multiqc_flowcell_config.yaml
@@ -10,6 +10,8 @@ custom_logo: 'assets/UU_logo_tranp4f125px.png'
 custom_logo_url: 'http://sequencing.se'
 custom_logo_title: 'SNP&SEQ Technology Platform'
 
+plots_force_interactive: True
+
 run_modules:
     - fastqc
     - fastq_screen

--- a/config/multiqc_project_config.yaml
+++ b/config/multiqc_project_config.yaml
@@ -10,6 +10,8 @@ custom_logo: 'assets/UU_logo_tranp4f125px.png'
 custom_logo_url: 'http://sequencing.se'
 custom_logo_title: 'SNP&SEQ Technology Platform'
 
+plots_force_interactive: True 
+
 run_modules:
     - fastqc
     - fastq_screen


### PR DESCRIPTION
MultiQC plots will now be forced to be interactive. This is not recommended for huge number of samples, from MultiQC docs: 

> This approach is not recommended if you have a very large number of samples, as this can produce a huge report file with all of the embedded plot data and crash your browser when opening it.

In cases where this happen I suggest we create the reports on Uppmax, setting this parameter to False. 