### PR TITLE
DEVELOP-515: Make Fastq Screen easier to interpret

### DIFF
--- a/config/multiqc_flowcell_config.yaml
+++ b/config/multiqc_flowcell_config.yaml
@@ -1,16 +1,4 @@
-# Config for flowcell Reports
-
-subtitle: "NGI Uppsala - SNP&SEQ Technology Platform"
-intro_text: |
-  This is a report containing quality control information about your project run at the SNP&SEQ Technology
-  Platform. If you have any questions, please do not hesitate to contact us at
-  <a href="mailto:seq@medsci.uu.se">seq@medsci.uu.se</a>
-
-custom_logo: 'assets/UU_logo_tranp4f125px.png'
-custom_logo_url: 'http://sequencing.se'
-custom_logo_title: 'SNP&SEQ Technology Platform'
-
-plots_force_interactive: True
+# Config for flowcell reports
 
 run_modules:
     - fastqc
@@ -29,7 +17,3 @@ top_modules:
     - 'custom_content'
     - 'bcl2fastq'
     - 'interop'
-
-remove_sections:
-    - 'fastqc_sequence_counts'
-

--- a/config/multiqc_main_config.yaml
+++ b/config/multiqc_main_config.yaml
@@ -1,0 +1,25 @@
+# MultiQC settings that apply to all reports
+
+subtitle: "NGI Uppsala - SNP&SEQ Technology Platform"
+intro_text: |
+  This is a report containing quality control information about your project run at the SNP&SEQ Technology
+  Platform. If you have any questions, please do not hesitate to contact us at
+  <a href="mailto:seq@medsci.uu.se">seq@medsci.uu.se</a>
+
+custom_logo: 'assets/UU_logo_tranp4f125px.png'
+custom_logo_url: 'http://sequencing.se'
+custom_logo_title: 'SNP&SEQ Technology Platform'
+
+plots_force_interactive: True
+
+fastqscreen_simpleplot: True
+
+# This makes sure only references with at least one match is shown.
+# This way, MultiQC will (in most cases) not have to reuse any color to represent references,
+# hence solving the problem where Human and PhiX had the same color
+custom_plot_config:
+  fastq_screen:
+    hide_zero_cats: True
+
+remove_sections:
+    - 'fastqc_sequence_counts'

--- a/config/multiqc_project_config.yaml
+++ b/config/multiqc_project_config.yaml
@@ -1,17 +1,5 @@
 # Config for project reports
 
-subtitle: "NGI Uppsala - SNP&SEQ Technology Platform"
-intro_text: |
-  This is a report containing quality control information about your project run at the SNP&SEQ Technology
-  Platform. If you have any questions, please do not hesitate to contact us at
-  <a href="mailto:seq@medsci.uu.se">seq@medsci.uu.se</a>
-
-custom_logo: 'assets/UU_logo_tranp4f125px.png'
-custom_logo_url: 'http://sequencing.se'
-custom_logo_title: 'SNP&SEQ Technology Platform'
-
-plots_force_interactive: True 
-
 run_modules:
     - fastqc
     - fastq_screen
@@ -24,5 +12,3 @@ table_columns_visible:
 top_modules:
     - 'custom_content'
 
-remove_sections:
-    - 'fastqc_sequence_counts'

--- a/main.nf
+++ b/main.nf
@@ -267,6 +267,7 @@ process multiqc_per_flowcell {
     multiqc \\
         --title "Flowcell report for \${RUNFOLDER}" \\
         --filename \${RUNFOLDER}_multiqc_report.html -z \\
+        -c ${config_dir}/multiqc_main_config.yaml \\
         -c ${config_dir}/multiqc_flowcell_config.yaml \\
         ${threshold_parameter} \\
         .
@@ -293,6 +294,7 @@ process multiqc_per_project {
         --title "Report for project ${project} on runfolder \${RUNFOLDER}" \\
         --filename \${RUNFOLDER}_${project}_multiqc_report.html -z \\
         -o ${project} \\
+        -c ${config_dir}/multiqc_main_config.yaml \\
         -c ${config_dir}/multiqc_project_config.yaml \\
         .
     """


### PR DESCRIPTION
- General multiqc settings have been moved to a main config.
- FastQ Screen:
  - Only references with at least one hit is shown in plot. This should (in most cases) make sure that MultiQC don't have to reuse colors.
  - The simple plot is now forced, making sure the plots look the same despite of the number of samples.