### PR TITLE
DEVELOP-811: Put fastqc and fastq screen results in folders

### DIFF
--- a/main.nf
+++ b/main.nf
@@ -159,11 +159,12 @@ process fastqc {
     tuple project, path(fastq_file)
 
     output:
-    tuple project, path("*_fastqc.{zip,html}")
+    tuple project, path("*_results")
 
     script:
     """
-    fastqc -t ${task.cpus} $fastq_file
+    mkdir -p $fastq_file"_fastqc_results"
+    fastqc -t ${task.cpus} -o $fastq_file"_fastqc_results" $fastq_file
     """
 }
 
@@ -175,7 +176,7 @@ process fastq_screen {
     path fastqscreen_databases
 
     output:
-    tuple project, path("*_screen.{txt,html}")
+    tuple project, path("*_results")
 
     script:
     """
@@ -186,7 +187,8 @@ process fastq_screen {
     elif [ "${fastqscreen_databases}" != "${fastqscreen_default_databases}" ]; then
         sed -i 's#${fastqscreen_default_databases}#${fastqscreen_databases}#' fastq_screen.conf
     fi
-    fastq_screen --conf fastq_screen.conf $fastq_file
+    mkdir -p $fastq_file"_fastq_screen_results"
+    fastq_screen --conf fastq_screen.conf --outdir $fastq_file"_fastq_screen_results" $fastq_file
     """
 }
 

--- a/nextflow.config
+++ b/nextflow.config
@@ -28,6 +28,7 @@ profiles {
             clusterOptions = { "-A $params.project" }
             cpus = 1
             memory = '8G'
+            time = '3h'
         }
         includeConfig "$baseDir/config/compute_resources.config"
     }


### PR DESCRIPTION
When running the pipeline on Irma on a large dataset, we encountered an issue where a MultiQC job could not be submitted to slurm due to the script being too large (11 MB!). Nextflow puts symlinks to all input files in the work directory and with a lot of input --> large number of lines. By writing the FastQC and FastQ Screen results to folders, the folders will be symlinked instead, reducing the number of lines by half. 

Also, add a job time to the Irma profile, since the default of 8 seconds won't be enough in most cases.  