### PR TITLE
DEVELOP-1090: Add high memory label to MultiQC jobs

### DIFF
--- a/config/compute_resources.config
+++ b/config/compute_resources.config
@@ -1,8 +1,11 @@
 process {
     withName: 'fastq_screen' {
-        memory = '4 G'
+        memory = '4G'
     }
     withName: 'get_QC_thresholds' {
         errorStrategy = 'ignore'
+    }
+    withLabel: 'high_memory' {
+        memory = '47G'
     }
 }

--- a/main.nf
+++ b/main.nf
@@ -255,6 +255,7 @@ process interop_summary {
 }
 
 process multiqc_per_flowcell {
+    label 'high_memory'
 
     input:
     val runfolder_name              // Run folder name
@@ -286,6 +287,7 @@ process multiqc_per_flowcell {
 }
 
 process multiqc_per_project {
+    label 'high_memory'
 
     input:
     val runfolder_name

--- a/nextflow.config
+++ b/nextflow.config
@@ -5,7 +5,7 @@ manifest {
     description = 'A Nextflow run folder QC pipeline for SciLifeLab SNP&SEQ platform'
     mainScript = 'main.nf'
     nextflowVersion = '!>=20.01.0'
-    version = '1.0'
+    version = '1.0.1'
 }
 
 profiles {
@@ -16,6 +16,13 @@ profiles {
         executor.name = 'local'
         executor.memory = '12G'
         includeConfig "$baseDir/config/compute_resources.config"
+        
+        // Overwrite high_memory label  
+        process {
+            withLabel: 'high_memory' {
+                memory = '12G'
+            }
+        }
     }
 
     irma {


### PR DESCRIPTION
This PR adds a high memory label specifying that a specific amount of memory* is required for a process. This label has been added to all MultiQC jobs to avoid a problem where multiple MultiQC jobs are started at the same time and take up too much memory. This can happen when processing projects where number of samples and data amount is high.

Tested locally on my machine. I could confirm that the MultiQC processes weren't running in parallel using the [timeline option.](https://www.nextflow.io/docs/latest/tracing.html#timeline-report)

\* The default value is set to 47 GB since that is the amount of memory we have in our staging and production environment. 