### PR TITLE
Update max memory in snpseq profile

### DIFF
--- a/nextflow.config
+++ b/nextflow.config
@@ -5,7 +5,7 @@ manifest {
     description = 'A Nextflow run folder QC pipeline for SciLifeLab SNP&SEQ platform'
     mainScript = 'main.nf'
     nextflowVersion = '!>=20.01.0'
-    version = '1.0.1'
+    version = '1.0.2'
 }
 
 profiles {
@@ -44,7 +44,7 @@ profiles {
         executor {
             name = 'local'
             cpus = 8
-            memory = '32G'
+            memory = '47G'
         }
         process {
             shell = ['/bin/bash', '-euo', 'pipefail']


### PR DESCRIPTION
This PR fixes a problem where the max memory limit hadn't been updated in the snpseq profile, leading to `high_memory` jobs failing since they require 47 GB of memory.

This change has been tested successfully in our staging environment. 