### PR TITLE
DEVELOP-721: removing checkqc threshold check

### DIFF
--- a/bin/get_qc_config.py
+++ b/bin/get_qc_config.py
@@ -31,11 +31,6 @@ class HandlerMapper:
                 multiqc_mapping="percent_Q30",
                 compare_direction="lt",
             ),
-            ValueHandlerMapper(
-                handler_name="ReadsPerSampleHandler",
-                multiqc_mapping="mqc-generalstats-bcl2fastq-total",
-                compare_direction="lt",
-            ),
         ]
 
         self.mapping = self._convert_to_mappings(self._mapper_list)

--- a/tests/unit_tests/test_get_qc_config.py
+++ b/tests/unit_tests/test_get_qc_config.py
@@ -75,6 +75,5 @@ def test_convert_to_multiqc_config(checkqc_config_dict):
     multiqc_config = convert_to_multiqc_config(checkqc_config_dict)
     multiqc_section = multiqc_config["table_cond_formatting_rules"]
     assert multiqc_section["Error"]["warn"] == [{"gt": 2}]
-    assert multiqc_section["mqc-generalstats-bcl2fastq-total"]["fail"] == [{"lt": 13.5}]
     assert multiqc_section["percent_Q30"]["warn"] == [{"lt": 80}]
     assert multiqc_section["total"]["warn"] == [{"lt": 18}]


### PR DESCRIPTION
The code here has removed ReadsPerSample as the reads per sample threshold was been taken directly from the config, but we need it to be divided with the number of samples in the lane.
This is the quick fix as implementing the reads per sample threshold was only now been used in the flowcell report, and in that one we include all projects.