### PR TITLE
Formatted with black and added pull-request event trigger on GHA

### DIFF
--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -1,5 +1,5 @@
 name: Run tests
-on: [push]
+on: [push, pull_request]
 jobs:
   run-tests:
     runs-on: ubuntu-20.04

--- a/bin/get_qc_config.py
+++ b/bin/get_qc_config.py
@@ -99,8 +99,7 @@ if __name__ == "__main__":
     both_read_lengths = run_type_recognizer.read_length()
     read_length = int(both_read_lengths.split("-")[0])
     checkqc_config = config.get_handler_configs(
-        instrument_and_reagent_version, read_length,
-        use_closest_read_length=True
+        instrument_and_reagent_version, read_length, use_closest_read_length=True
     )
     checkqc_config_dict = convert_to_dict(checkqc_config)
     multiqc_config = convert_to_multiqc_config(checkqc_config_dict)


### PR DESCRIPTION
The parameter use_closest_read_length is set to True to enable to find_closest_read_length if the given readlength is not in the config
- Formatted with black and added pull-request event trigger on GHA