### PR TITLE
Read version info from `nf-core/demultiplex` version file

### DIFF
--- a/bin/get_metadata.py
+++ b/bin/get_metadata.py
@@ -88,8 +88,8 @@ class RunfolderInfo:
         with open(Path(runfolder) / "pipeline_info" / "software_versions.yml") as f:
             return {
                 software: version
-                for sotfware_dict in yaml.safe_load(f).values()
-                for software, version in sotfware_dict.items()
+                for software_dict in yaml.safe_load(f).values()
+                for software, version in software_dict.items()
             }
 
     def get_run_parameters(self):

--- a/bin/get_metadata.py
+++ b/bin/get_metadata.py
@@ -86,7 +86,7 @@ class RunfolderInfo:
 
     def get_software_version(self, runfolder):
         with open(Path(runfolder) / "pipeline_info" / "software_versions.yml") as f:
-            return { 
+            return {
                 software: version
                 for sotfware_dict in yaml.safe_load(f).values()
                 for software, version in sotfware_dict.items()
@@ -140,9 +140,7 @@ class RunfolderInfo:
             pass
 
         try:
-            return {
-                "Demultiplexing": self.get_software_version(self.runfolder)
-            }
+            return {"Demultiplexing": self.get_software_version(self.runfolder)}
         except FileNotFoundError:
             pass
 

--- a/bin/get_metadata.py
+++ b/bin/get_metadata.py
@@ -7,6 +7,7 @@ import argparse
 import os
 import json
 from pathlib import Path
+import yaml
 
 
 class RunfolderInfo:
@@ -85,11 +86,11 @@ class RunfolderInfo:
 
     def get_software_version(self, runfolder):
         with open(Path(runfolder) / "pipeline_info" / "software_versions.yml") as f:
-            return dict(
-                line.strip().split(": ")
-                for line in f.readlines()
-                if line.startswith("  ")
-            )
+            return { 
+                software: version
+                for sotfware_dict in yaml.safe_load(f).values()
+                for software, version in sotfware_dict.items()
+            }
 
     def get_run_parameters(self):
         results = OrderedDict()

--- a/bin/get_metadata.py
+++ b/bin/get_metadata.py
@@ -127,17 +127,26 @@ class RunfolderInfo:
         if flowcell_type:
             results.update(flowcell_type)
 
-        try:
-            results["bcl2fastq version"] = self.get_bcl2fastq_version(self.runfolder)
-        except FileNotFoundError:
-            pass
-
-        try:
-            results.update(self.get_software_version(self.runfolder))
-        except FileNotFoundError:
-            pass
-
         return results
+
+    def get_demultiplexing_info(self):
+        try:
+            return {
+                "Demultiplexing": {
+                    "bcl2fastq": self.get_bcl2fastq_version(self.runfolder)
+                }
+            }
+        except FileNotFoundError:
+            pass
+
+        try:
+            return {
+                "Demultiplexing": self.get_software_version(self.runfolder)
+            }
+        except FileNotFoundError:
+            pass
+
+        return {}
 
 
 if __name__ == "__main__":
@@ -157,7 +166,7 @@ if __name__ == "__main__":
     bcl2fastq_outdir = args.bcl2fastq_outdir
 
     runfolder_info = RunfolderInfo(runfolder, bcl2fastq_outdir)
-    results = runfolder_info.get_info()
+    info = runfolder_info.get_info()
 
     print(
         """
@@ -169,6 +178,11 @@ data: |
     <dl class="dl-horizontal">
 """
     )
-    for k, v in results.items():
-        print("        <dt>{}</dt><dd><samp>{}</samp></dd>".format(k, v))
+    for k, v in info.items():
+        print(f"        <dt>{k}</dt><dd><samp>{v}</samp></dd>")
+
+    print("        <dt>Demultiplexing</dt>")
+    for software, version in runfolder_info.get_demultiplexing_info().items():
+        print(f"            <dd>{software}: <samp>{version}</samp></dd>")
+
     print("    </dl>")

--- a/test_data/210510_M03910_0104_000000000-JHGJL/pipeline_info/software_versions.yml
+++ b/test_data/210510_M03910_0104_000000000-JHGJL/pipeline_info/software_versions.yml
@@ -1,0 +1,8 @@
+BCL2FASTQ:
+  bcl2fastq: 2.20.0.422
+CUSTOM_DUMPSOFTWAREVERSIONS:
+  python: 3.12.0
+  yaml: 6.0.1
+Workflow:
+  Nextflow: 23.04.3
+  nf-core/demultiplex: 1.5.0dev

--- a/tests/unit_tests/test_get_metadata.py
+++ b/tests/unit_tests/test_get_metadata.py
@@ -57,6 +57,18 @@ def test_bcl2fastq_version(runfolder_info):
     )
     assert bcl2fastq_version == "2.20.0.422"
 
+def test_get_software_version(runfolder_info):
+    software_versions = runfolder_info.get_software_version(
+        "test_data/210510_M03910_0104_000000000-JHGJL"
+    )
+
+    assert software_versions == {
+      "bcl2fastq": "2.20.0.422",
+      "python": "3.12.0",
+      "yaml": "6.0.1",
+      "Nextflow": "23.04.3",
+      "nf-core/demultiplex": "1.5.0dev",
+    }
 
 def test_get_run_parameters(runfolder_info):
     filtered_run_parameters = runfolder_info.get_run_parameters()
@@ -95,4 +107,4 @@ def test_get_read_cycles(runfolder_info):
 
 def test_get_info(runfolder_info):
     results = runfolder_info.get_info()
-    assert len(results) == 10
+    assert len(results) == 15

--- a/tests/unit_tests/test_get_metadata.py
+++ b/tests/unit_tests/test_get_metadata.py
@@ -57,18 +57,20 @@ def test_bcl2fastq_version(runfolder_info):
     )
     assert bcl2fastq_version == "2.20.0.422"
 
+
 def test_get_software_version(runfolder_info):
     software_versions = runfolder_info.get_software_version(
         "test_data/210510_M03910_0104_000000000-JHGJL"
     )
 
     assert software_versions == {
-      "bcl2fastq": "2.20.0.422",
-      "python": "3.12.0",
-      "yaml": "6.0.1",
-      "Nextflow": "23.04.3",
-      "nf-core/demultiplex": "1.5.0dev",
+        "bcl2fastq": "2.20.0.422",
+        "python": "3.12.0",
+        "yaml": "6.0.1",
+        "Nextflow": "23.04.3",
+        "nf-core/demultiplex": "1.5.0dev",
     }
+
 
 def test_get_run_parameters(runfolder_info):
     filtered_run_parameters = runfolder_info.get_run_parameters()

--- a/tests/unit_tests/test_get_metadata.py
+++ b/tests/unit_tests/test_get_metadata.py
@@ -109,4 +109,4 @@ def test_get_read_cycles(runfolder_info):
 
 def test_get_info(runfolder_info):
     results = runfolder_info.get_info()
-    assert len(results) == 15
+    assert len(results) == 9


### PR DESCRIPTION
This PR adds support for runfolders processed with [nf-core/demultiplex](https://github.com/nf-core/demultiplex/) instead of [arteria-bcl2fastq](https://github.com/arteria-project/arteria-bcl2fastq/).

In the current version of snpseq_packs, the version of bcl2fastq is dumped to a file during processing. This won't be needed in the future since all nf-core pipelines collect all software versions in a single file.