### PR TITLE
Increase job time for FastQC and Fastq screen

### DIFF
--- a/config/nextflow_config/compute_resources.config
+++ b/config/nextflow_config/compute_resources.config
@@ -1,6 +1,10 @@
 process {
+    withName: 'FASTQC' {
+        time = '6h'
+    }
     withName: 'FASTQ_SCREEN' {
         memory = '4G'
+        time = '6h'
     }
     withName: 'GET_QC_THRESHOLDS' {
         errorStrategy = 'ignore'

--- a/config/nextflow_config/compute_resources.config
+++ b/config/nextflow_config/compute_resources.config
@@ -1,10 +1,10 @@
 process {
     withName: 'FASTQC' {
-        time = '6h'
+        time = '12h'
     }
     withName: 'FASTQ_SCREEN' {
         memory = '4G'
-        time = '6h'
+        time = '12h'
     }
     withName: 'GET_QC_THRESHOLDS' {
         errorStrategy = 'ignore'


### PR DESCRIPTION
Solves issue where slurm job for FastQC would be cancelled due to time limit. I increased the time for fastq screen as well, since these jobs also takes longer with larger data sizes. 

It would be more optimal to have a solution like nf-core pipelines have, where processes failing with this error code are re-run with incrementally increasing compute resources. I do however see no reason to implement this in this pipeline, since the long-term plan is to use switch to the nf-core/seqinspector.