### PR TITLE
DATAOPS-750: Persisting tables in seqreports General Statistics when …

### DIFF
--- a/config/tool_config/multiqc_main_config.yaml
+++ b/config/tool_config/multiqc_main_config.yaml
@@ -151,3 +151,6 @@ sp:
     fn: "rrna_table.tsv"
   rrna_plot:
     fn: "rrna_plot.tsv"
+
+max_table_rows: 100000
+


### PR DESCRIPTION
Persisting tables in seqreports General Statistics when samples are over the 500 limit

Verification protocol: https://snpseq.atlassian.net/wiki/spaces/AR/pages/3545071617/Verification+of+sequencing-report-service+v1.5.1-rc1