### PR TITLE
DATAOPS-815: Increase resources for high_memory_and_cpus label

### DIFF
--- a/config/nextflow_config/compute_resources.config
+++ b/config/nextflow_config/compute_resources.config
@@ -10,7 +10,7 @@ process {
         errorStrategy = 'ignore'
     }
     withLabel: 'high_memory_and_cpus' {
-        memory = '47G'
-        cpus = 8
+        memory = '100G'
+        cpus = 16
     }
 }


### PR DESCRIPTION
We ran into the same issue as before (https://github.com/Molmed/seqreports/pull/62) and it seems like we need to increase compute resources even more. 