### PR TITLE
Rename final high_memory label to high_memory_and_cpus

### DIFF
--- a/main.nf
+++ b/main.nf
@@ -313,7 +313,7 @@ process MULTIQC_PER_FLOWCELL {
 process MULTIQC_PER_PROJECT {
 
     publishDir "${params.result_dir}/projects", mode: 'copy', overwrite: true
-    label 'high_memory'
+    label 'high_memory_and_cpus'
 
     input:
     val runfolder_name


### PR DESCRIPTION
I missed to rename one label during https://github.com/Molmed/seqreports/pull/62. Corrected now. 
