### PR TITLE
Fetch read length info for run instead of just lane 1

### DIFF
--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -11,7 +11,7 @@ jobs:
         uses: actions/checkout@v2
 
       - name: Cache singularity images
-        uses: actions/cache@v2
+        uses: actions/cache@v4.2.2
         with:
           path: work/singularity
           key: singularity-${{ hashFiles('config/nextflow_config/singularity.config') }}

--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -2,7 +2,7 @@ name: Run tests
 on: [push, pull_request]
 jobs:
   run-tests:
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-22.04
     env:
       NXF_VER: 21.04.1
       NXF_ANSI_LOG: false

--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -2,7 +2,7 @@ name: Run tests
 on: [push, pull_request]
 jobs:
   run-tests:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     env:
       NXF_VER: 21.04.1
       NXF_ANSI_LOG: false

--- a/bin/get_metadata.py
+++ b/bin/get_metadata.py
@@ -122,8 +122,8 @@ class RunfolderInfo:
 
             # Handle potential cases with only one Read element
             if isinstance(reads, dict):
-               reads = [reads]  # Wrap it in a list to make it iterable
-            
+                reads = [reads]  # Wrap it in a list to make it iterable
+
             for read_info in reads:
                 if read_info["@IsIndexedRead"] == "Y":
                     read_and_cycles[f"Index {index_counter} (bp)"] = read_info[
@@ -136,7 +136,7 @@ class RunfolderInfo:
                     ]
                     read_counter += 1
             return read_and_cycles
-        
+
         except TypeError:
             return read_and_cycles
 

--- a/bin/get_metadata.py
+++ b/bin/get_metadata.py
@@ -6,6 +6,7 @@ import re
 import argparse
 import os
 import json
+from operator import itemgetter
 from pathlib import Path
 import yaml
 
@@ -124,7 +125,7 @@ class RunfolderInfo:
             if isinstance(reads, dict):
                 reads = [reads]  # Wrap it in a list to make it iterable
 
-            for read_info in reads:
+            for read_info in sorted(reads, key=itemgetter("@Number")):
                 if read_info["@IsIndexedRead"] == "Y":
                     read_and_cycles[f"Index {index_counter} (bp)"] = read_info[
                         "@NumCycles"

--- a/main.nf
+++ b/main.nf
@@ -61,12 +61,6 @@ def helpMessage() {
     """
 }
 
-def printVersion() {
-
-    log.info "seqreports v${workflow.manifest.version}"
-
-}
-
 printVersion()
 
 if (params.help || !params.run_folder){

--- a/main.nf
+++ b/main.nf
@@ -61,8 +61,6 @@ def helpMessage() {
     """
 }
 
-printVersion()
-
 if (params.help || !params.run_folder){
     helpMessage()
     exit 0

--- a/nextflow.config
+++ b/nextflow.config
@@ -5,7 +5,6 @@ manifest {
     description = 'A Nextflow run folder QC pipeline for SciLifeLab SNP&SEQ platform'
     mainScript = 'main.nf'
     nextflowVersion = '!>=21.04.1'
-    version = '1.2.0'
 }
 
 profiles {

--- a/tests/unit_tests/test_get_metadata.py
+++ b/tests/unit_tests/test_get_metadata.py
@@ -108,3 +108,8 @@ def test_get_read_cycles(runfolder_info):
 def test_get_info(runfolder_info):
     results = runfolder_info.get_info()
     assert len(results) == 9
+
+
+def test_read_run_info(runfolder_info):
+    run_info = runfolder_info.read_run_info()
+    assert len(run_info["RunInfo"]["Run"]["Reads"]["Read"]) == 4


### PR DESCRIPTION
**Description:**

Previously, get_metadata.py reported the read and index length based on the information from lane 1 which could be misleading in some cases. Therefore, it was decided that the script should be updated so that it shows the read length setting for the run instead. 
In this update, this is achieved by fetching length information from RunInfo.xml

Also updated actions/cache from v2 --> v4.2.2 to enable automatic testing 

**Risk analysis:**

The scripts will most likely fail if there are updates to the structure of the RunInfo.xml file.  However, the damage from this would be minimal and should be noticed immediately. 

**Validation procedure:**

Run ngi work flow, generate reports and makes sure that the expected read and index lengths are printed in the report.